### PR TITLE
Fix of parsing of git ahead information 

### DIFF
--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@ dvcs_function="
 
             # :git-ahead
                 # How many local commits do you have ahead of origin?
-                num=\$(echo \$gitStatus | grep \"Your branch is ahead of\" | awk '{split(\$0,a,\" \"); print a[13];}') || return
+                num=\$(echo \$gitStatus | grep \"Your branch is ahead of\" | awk '{split(\$0,a,\" \"); print a[11];}') || return
                 if [ -n \"\$num\" ]; then
                     prompt=\$prompt\"\\[\$color-git-ahead\\] +\$num\"
                 fi

--- a/index.html
+++ b/index.html
@@ -497,7 +497,7 @@ dvcs_function="
 
             # :git-ahead
                 # How many local commits do you have ahead of origin?
-                num=\$(echo \$gitStatus | grep \"Your branch is ahead of\" | awk '{split(\$0,a,\" \"); print a[11];}') || return
+                num=\$(echo \"\$gitStatus\" | grep \"Your branch is ahead of\" | awk '{split(\$0,a,\" \"); print a[8];}') || return
                 if [ -n \"\$num\" ]; then
                     prompt=\$prompt\"\\[\$color-git-ahead\\] +\$num\"
                 fi

--- a/index.html
+++ b/index.html
@@ -458,7 +458,7 @@ dvcs_function="
 
             # :git-modified
                 # changed *tracked* files in local directory?
-                gitChange=\$(echo \$gitStatus | ack 'modified:|deleted:|new file:')
+                gitChange=\$(echo \$gitStatus | ack-grep 'modified:|deleted:|new file:')
                 if [ -n \"\$gitChange\" ]; then
                     gitChange=\"\\[\$color-git-modified\\] \\[`tput sc`\\]  \\[`tput rc`\\]\\[\$DELTA_CHAR\\] \"
                 fi


### PR DESCRIPTION
the output of git version 1.9.1 is not anymore parsed correctly.
With one commit that is ahead, the resulting prompt of the original code was:

> xxxxxxxxxxxxxxxxxxxxxx (unstable:54b6478) +(use $

using the fix:

> xxxxxxxxxxxxxxxxxxxxxx (unstable:54b6478) +1 $
